### PR TITLE
Fix PDF package import and ensure tests run

### DIFF
--- a/app/pdf/__init__.py
+++ b/app/pdf/__init__.py
@@ -1,0 +1,1 @@
+"""PDF generation utilities."""

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
## Summary
- add missing __init__ to PDF utilities so `app.pdf` imports succeed
- ensure repository root is on `sys.path` during tests
- configure pytest to only collect tests under `tests`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899c07554f88333be98cee6b5bf3c23